### PR TITLE
starting to make the minix_x86.img bootable

### DIFF
--- a/releasetools/x86_hdimage.sh
+++ b/releasetools/x86_hdimage.sh
@@ -190,7 +190,9 @@ _HOME_SIZE=$((`${CROSS_TOOLS}/nbmkfs.mfs -d ${HOMESIZEARG} -I $((${HOME_START}*5
 # minix partition utility
 #
 ${CROSS_TOOLS}/nbpartition -m ${IMG} 0 81:${ISO_SIZE} \
-	81:${_ROOT_SIZE} 81:${_USR_SIZE} 81:${_HOME_SIZE}
+	81:${_ROOT_SIZE}* 81:${_USR_SIZE} 81:${_HOME_SIZE}
+
++dd if=${DESTDIR}/usr/mdec/mbr of=${IMG} conv=notrunc bs=446 count=1
 
 mods="`( cd ${MODDIR}; echo mod* | tr ' ' ',' )`"
 if [ "x${ISOMODE}" = "x1" ]


### PR DESCRIPTION
The image created via x86_hdimage.sh (minix_x86.img) is used for starting QEMU. However, its not far away from being bootable via "qemu-system-i386 -hda test_x86.img", too. This comit allows to boot the MBR but it still fails to boot the partition boot record, which needs to be inserted.
